### PR TITLE
Error handling + hash table integration

### DIFF
--- a/include/json.h
+++ b/include/json.h
@@ -1,7 +1,47 @@
 #ifndef JSON_JSON_H
 #define JSON_JSON_H
 
-#include "parser.h"
+typedef enum {
+    JSON_OBJECT,
+    JSON_ARRAY,
+    JSON_STRING,
+    JSON_NUMBER,
+    JSON_BOOLEAN,
+    JSON_NULL
+} JsonType;
+
+typedef struct JsonValue JsonValue;
+typedef struct JsonMember JsonMember;
+typedef struct JsonTable JsonTable;
+
+struct JsonTable {
+    JsonMember *members;
+    char **keys;
+    size_t count;
+    size_t capacity;
+};
+
+struct JsonValue {
+    JsonType type;
+    int line;
+    union {
+        JsonTable object;
+        struct {
+            JsonValue *values;
+            size_t count;
+            size_t capacity;
+        } array;
+        char *string;
+        double number;
+        int boolean;
+    } as;
+};
+
+struct JsonMember {
+    char *key;
+    JsonValue value;
+};
+
 
 JsonValue *json_array_get(JsonValue *value, size_t index);
 JsonValue *json_object_get(JsonValue *value, char *key);

--- a/include/json_error.h
+++ b/include/json_error.h
@@ -1,0 +1,8 @@
+#ifndef JSON_ERROR_H
+#define JSON_ERROR_H
+
+#define HANDLE_ERROR(message) handle_error(message, __LINE__, __FILE__, __func__)
+
+void handle_error(char *message, int line, char *file, const char *func);
+
+#endif 

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -22,6 +22,7 @@ typedef enum {
 typedef struct {
     TokenType type;
     const char *string;
+    int line;
 } Token;
 
 void lexer_init(const char *source);

--- a/include/parser.h
+++ b/include/parser.h
@@ -2,43 +2,7 @@
 #define JSON_PARSER_H
 
 #include "lexer.h"
-
-#define JSON_VALUE_ERROR (JsonValue) {.type = JSON_ERROR}
-
-typedef enum {
-    JSON_OBJECT,
-    JSON_ARRAY,
-    JSON_STRING,
-    JSON_NUMBER,
-    JSON_BOOLEAN,
-    JSON_NULL,
-    JSON_ERROR
-} JsonType;
-
-typedef struct JsonValue JsonValue;
-typedef struct JsonMember JsonMember;
-
-struct JsonValue {
-    JsonType type;
-    union {
-        struct {
-            JsonMember *members; 
-            size_t count;
-        } object;
-        struct {
-            JsonValue *values;
-            size_t count;
-        } array;
-        char *string;
-        double number;
-        int boolean;
-    } as;
-};
-
-struct JsonMember {
-    char *key;
-    JsonValue value;
-};
+#include "json.h"
 
 JsonValue *json_parse(Token *tokens, size_t token_count);
 

--- a/include/table.h
+++ b/include/table.h
@@ -2,18 +2,13 @@
 #define JSON_TABLE_H
 
 #include "parser.h"
+#include "json.h"
 
-typedef struct {
-    size_t count;
-    size_t capacity;
-    JsonMember *members;
-} Table;
-
-void json_table_init(Table *table);
-void json_table_free(Table *table);
-bool json_table_get(Table *table, char *key, JsonValue *value);
-bool json_table_set(Table *table, char *key, JsonValue value);
-bool json_table_delete(Table *table, char *key); 
-void json_table_copy(Table *from, Table *to);
+void json_table_init(JsonTable *table);
+void json_table_free(JsonTable *table);
+JsonValue *json_table_get(JsonTable *table, char *key);
+bool json_table_set(JsonTable *table, char *key, JsonValue value);
+bool json_table_delete(JsonTable *table, char *key); 
+void json_table_copy(JsonTable *from, JsonTable *to);
 
 #endif

--- a/src/json_error.c
+++ b/src/json_error.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+#include "json_error.h"
+
+void handle_error(char *message, int line, char *file, const char *func) {
+    fprintf(stderr, "ERROR at %d, %s, %s: %s\n", line, file, func, message);
+}

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -6,10 +6,12 @@
 
 char *start;
 char *current;
+int line;
 
 void lexer_init(const char *source) {
     start = source;
     current = source;
+    line = 1;
 }
 
 static bool is_digit(char c) {
@@ -41,6 +43,7 @@ static Token make_token(TokenType type, char *string) {
     Token token;
     token.type = type;
     token.string = string;
+    token.line = line;
     return token;
 }
 
@@ -48,6 +51,7 @@ static Token make_error_token(char *message) {
     Token token;
     token.type = TOKEN_ERROR;
     token.string = message;
+    token.line = line;
     return token;
 }
 
@@ -123,8 +127,11 @@ void skip_whitespace() {
             case ' ':
             case '\t':
             case '\r':
+                advance();
+                break;
             case '\n':
                 advance();
+                line++;
                 break;
             default: 
                 return;
@@ -156,6 +163,6 @@ Token scan_token() {
 }
 
 void print_token(Token token) {
-    printf("Type: %12s  Content: %s", token_type_to_string(token.type), token.string);
+    printf("Type: %12s\nContent: %s\nLine: %d", token_type_to_string(token.type), token.string, token.line);
     printf("\n");
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,19 +1,32 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "file.h"
 #include "json.h"
 #include "table.h"
-#include "lexer.h"
-#include "file.h"
-#include "parser.h"
-#include "string_builder.h"
 
-int main() {
+void test_json() {
     const char *source = read_file("data/test/object.json");
 
     JsonValue *value = json_init(source);
 
+    printf("\n\nIn main:\n");
     json_print(value);
+}
+
+void test_table() {
+    JsonTable table;
+    JsonValue *value = malloc(sizeof(JsonValue));
+    value->type = JSON_NUMBER;
+    value->as.number = 10.0;
+    json_table_init(&table);
+    json_table_set(&table, "key1", *value);
+    
+    JsonValue *get_value = json_table_get(&table, "key1");
+}
+
+int main() {
+    test_json();
 
     return 0;
 }


### PR DESCRIPTION
1. Implemented error handling
2. Connected hash table with `JSON_OBJECT`s

## Error handling:
- Added `json_error.h` and `json_error.c`
- call `HANDLE_ERROR(message)` to output an error message in stderr.

Closes #1.

## Hash table:
- Renamed `Table` into `JsonTable` for consistency
- Moved struct definitions from `parser.h` into `json.h`
- `json_table_get` in `table.c` now returns a `JsonValue *` instead of storing the value in a reference.
- Added a list of keys in `JsonTable` to get the order of objects stored.

Untested:
- `json_table_delete`